### PR TITLE
Veri-policy module

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -11,3 +11,5 @@ PKG oUnit
 PKG bap
 PKG bap-traces
 PKG bap-piqi-traces
+PKG pcre
+PKG textutils

--- a/README.md
+++ b/README.md
@@ -1,9 +1,89 @@
 # bil-verification
 
-bil verification tool
+A central goal of this tool is to find errors in our BIL code. So this tool 
+compares results of instructions execution in trace with execution of BIL code,
+that describes this instructions. Verification is based on comparison of two 
+set of events. First one is a real events set, that came from trace. And second 
+one is a set, that was filled during execution of `code_exec` event, by 
+emitting artificial events.
 
-This tool compares the results of the execution in the trace with the
-execution of our lifted IL. A central goal is to use this feature to
-find errors in our lifting instructions, which happen when the
-execution of the IL does not match that of the concrete instruction
-trace.
+##Build and install
+```
+oasis setup
+./configure --prefix=`opam config var prefix`
+make
+make install
+```
+##Policy
+
+There is an ideal case when all events from trace and all events from
+BIL are equal to each other. But in practice both trace and bil could
+contain some special cases. For example, trace could be obtained from
+source, that does not provide some cpu flags, or bil does not support
+some instructions.  And we possible may want to shadow this cases and
+continue verification process. From other point of view, we do not want 
+to miss errors. So for this reasons tool supports policy, that is a set
+of rules with the following grammar.
+
+Each rule consists of 4 fields: `ACTION INSN L_EVENT R_EVENT`
+
+1. `ACTION`  field could be either `SKIP`, either `DENY`. If we have processed 
+   trace without matching with any `DENY`, then everything is ok.
+2. `INSN`    field could contain an instruction name like `MOV64rr` or regular 
+   expression, like `MOV.*`
+3. `L_EVENT` field, left hand-side event, corresponds to textual representation 
+   of tracer events, and could contain any string and regualar expression. 
+4. `R_EVENT` field, right hand-side event, corresponds to textual representation
+   of lifter events, and could contain any string and regualar expression. 
+
+Matching is performed textually, based on event syntax. Regexp syntax supports
+backreferences in event fields. Only that events, that don't have an equal
+pair in other set goes to this matching. 
+
+Rules could be written in text file, that will be passed as argument through
+command line. Syntax is a pretty simple. Each row either contains a rule,
+either commented with `#` symbol, either empty. Rule must have exactly 
+4 fields. An empty field must be written as `''` or `""`. Fields with spaces 
+must be written in quotes: `"RAX => .*"`, single quotes also supported:
+`'RAX => .*'`.
+
+###Examples
+
+For example, let's imagine that a tracer doesn't support read from zero 
+flag, so all read events from zero flag in bil code will be unmatched. 
+So we are able to create next rule :
+`SKIP .* '' 'ZF -> .*'`
+This could be read as: for any instruction skip unmatched zero flag 
+reading in bil code.
+
+Next two rules means that that no one should be left without a pair.
+```
+DENY .* .* ''
+DENY .* '' .*
+```
+That does mean that for any instruction unmatched left/right event is an error. 
+This pair is also a default behavior in case when there wasn't any policy file 
+given through a command line.
+
+Also we can use this policy to check incomplete lifter, for example we can say:
+```
+DENY MOV.* .* ''
+DENY MOV.* '' .*
+```
+And check only move instructions.
+
+Backreferenses example: `DENY .* '(.F) <= .*' '\1 <= .*'`, that could be read 
+as: for any instruction complain if a value written in some flag in tracer is 
+differrent from value written in lifter for the same flag. And values are 
+really different, since only not equal events goes to matching.
+
+##Usage
+Program works only with files with `.frames` extension.
+```
+bil-veri --show-errors --show-stat --rules "path to rules file" PATH
+
+`PATH` is either directory with files from a tracer, either a file.
+`show-errors` option allows to see a detailed information about BIL errors
+`show-stat` option allows to see a summary over a trace verification.
+
+```

--- a/_oasis
+++ b/_oasis
@@ -1,46 +1,59 @@
-OASISFormat: 0.4
-Name:        bil-veri
-Version:     0.2
-Synopsis:    Bil verification tool
-Authors:     BAP Team
-Maintainers: Ivan Gotovchits <ivg@ieee.org>,
-             Oleg Kamenkov <forown@yandex.ru>
-License:     MIT
-Copyrights:  (C) 2016 Carnegie Mellon University
-Plugins:     META (0.4), DevFiles (0.4)
-BuildTools: ocamlbuild
-BuildDepends: core_kernel
+OASISFormat:  0.4
+Name:         bil-veri
+Version:      0.2
+Synopsis:     Bil verification tool
+Authors:      BAP Team
+Maintainers:  Ivan Gotovchits <ivg@ieee.org>,
+              Oleg Kamenkov <forown@yandex.ru>
+License:      MIT
+Copyrights:   (C) 2016 Carnegie Mellon University
+Plugins:      META (0.4), DevFiles (0.4)
+BuildTools:   ocamlbuild
+BuildDepends: ppx_jane, core_kernel, bap, bap-traces
 
 Library veri
   Path:           lib
   FindLibName:    bap-veri
-  Modules:        Veri, Veri_error, Veri_report, Veri_traci
+  Modules:        Veri,
+                  Veri_error,
+                  Veri_policy,
+                  Veri_report,
+                  Veri_rule,
+                  Veri_stat,
+                  Veri_traci
   CompiledObject: best
-  BuildDepends:   bap, bap-traces
+  Install:        false
+  NativeOpt:      -pp 'ppx-jane -dump-ast'
+  ByteOpt:        -pp 'ppx-jane -dump-ast'
+  BuildDepends:   pcre, textutils, threads
 
 Library veri_test
-  Path:            tests
-  Install:         false
-  CompiledObject:  best
-  Modules:         Veri_test
-  BuildDepends:    bap, bap-traces, bap-veri, oUnit
+  Path:           tests
+  Build$:         flag(tests)
+  Install:        false
+  CompiledObject: best
+  Modules:        Veri_test, 
+                  Veri_policy_test, 
+                  Veri_rule_test, 
+                  Veri_stat_test
+  BuildDepends:   bap-veri, oUnit
 
-Executable veri_main
+Executable "bil-veri"
   Path:           src
   MainIs:         veri_main.ml
   CompiledObject: best
-  BuildDepends:   findlib.dynload, bap, bap.plugins, 
-                  bap-veri, bap-traces, cmdliner
+  Install:        true
+  BuildDepends:   findlib.dynload, bap.plugins, bap-veri, cmdliner
 
 Executable run_tests
   Path:           tests
   MainIs:         run_tests.ml
   Install:        false
   Build$:         flag(tests)
-  BuildDepends:   bap, bap-traces, bap.plugins, oUnit, findlib.dynload
   CompiledObject: best
+  BuildDepends:   bap.plugins, veri_test, oUnit, findlib.dynload
 
 Test veri_test
   TestTools:      run_tests
-  Run$:           flag(tests) 
+  Run$:           flag(tests)
   Command:        $run_tests -runner sequential

--- a/lib/veri.mli
+++ b/lib/veri.mli
@@ -1,8 +1,8 @@
 open Core_kernel.Std
 open Bap.Std
+open Regular.Std
 open Bap_traces.Std
-
-type error = Veri_error.t
+open Bap_future.Std
 
 module Disasm : sig
   module Dis = Disasm_expert.Basic
@@ -10,18 +10,24 @@ module Disasm : sig
   type t = (asm, kinds) Dis.t
 end
 
-class context: Veri_report.t -> Trace.t -> object('s)
+class context: Veri_stat.t -> Veri_policy.t -> Trace.t -> object('s)
     inherit Veri_traci.context
     method split : 's
     method merge : 's
-    method register_event : Trace.event -> 's
-    method events : Value.Set.t
     method other  : 's option
-    method replay : 's 
-    method report: Veri_report.t
-    method set_description: string -> 's
-    method notify_error: error -> 's
-    method backup: 's -> 's
+    method save: 's -> 's
+    method switch: 's
+    method stat : Veri_stat.t
+    method code : Chunk.t option
+    method events : Value.Set.t
+    method reports : Veri_report.t stream
+    method register_event : Trace.event -> 's
+    method discard_event : (Trace.event -> bool) -> 's
+    method notify_error: Veri_error.t -> 's
+    method set_bil : bil -> 's
+    method set_code : Chunk.t -> 's 
+    method set_insn: string -> 's
+    method drop_pc : 's
   end
 
 class ['a] t : arch -> Disasm.t -> (Trace.event -> bool) -> object('s)

--- a/lib/veri_policy.ml
+++ b/lib/veri_policy.ml
@@ -1,0 +1,166 @@
+open Core_kernel.Std
+open Graph
+open Bap.Std
+open Bap_traces.Std
+open Regular.Std
+
+module Rule = Veri_rule
+
+type event = Trace.event [@@deriving bin_io, compare, sexp]
+type events = Value.Set.t
+type rule = Rule.t [@@deriving bin_io, compare, sexp]
+
+module Matched = struct
+  type t = event list * event list [@@deriving bin_io, sexp]
+
+  include Regular.Make(struct
+      type nonrec t = t [@@deriving bin_io, compare, sexp]
+      let compare = compare
+      let hash = Hashtbl.hash
+      let module_name = Some "Veri_policy.Matched"
+      let version = "0.1"
+      let pp_ev fmt ev = Format.fprintf fmt "%a; " Value.pp ev
+
+      let pp_events pref fmt = function
+        | [] -> ()
+        | evs ->
+          Format.fprintf fmt "%s: " pref;
+          List.iter evs ~f:(pp_ev fmt);
+          Format.print_newline ()
+
+      let pp fmt (evs, evs') =
+        Format.fprintf fmt "%a%a"
+          (pp_events "left") evs (pp_events "right") evs'
+
+    end)
+end
+
+type matched = Matched.t [@@deriving bin_io, compare, sexp]
+type t = rule list [@@deriving bin_io, compare, sexp]
+ 
+let empty = []
+let add t rule : t = rule :: t
+
+let string_of_events ev ev' = 
+  String.concat ~sep:" " [Value.pps () ev; Value.pps () ev']
+  
+let sat_events r ev ev' =
+  Value.typeid ev = Value.typeid ev' &&
+  Rule.match_field r `Both (string_of_events ev ev')
+
+module G = struct
+  type t = rule * event array * event array
+  module V = struct
+    type t = Source | Sink | Person of int | Task of int [@@deriving compare]
+    let hash = Hashtbl.hash
+    let equal x y = compare x y = 0
+  end
+  module E = struct
+    type label = unit
+
+    type t = {src : V.t; dst : V.t} [@@deriving fields]
+    let make src dst = {src; dst}
+    let label _ = ()
+  end
+  type dir = Succ | Pred
+
+  let iter dir f (rule, workers, jobs) v = 
+    match v,dir with
+    | V.Source,Pred -> ()
+    | V.Source,Succ ->
+      Array.iteri workers ~f:(fun i _  ->
+          f @@ E.make V.Source (V.Person i))
+    | V.Sink,Pred ->
+      Array.iteri jobs ~f:(fun i _ ->
+          f @@ E.make (V.Task i) V.Sink)
+    | V.Sink,Succ -> ()
+    | V.Person i as p,Pred ->
+      f @@ E.make V.Source p
+    | V.Person i as p,Succ ->
+      Array.iteri jobs ~f:(fun j job ->
+          if sat_events rule workers.(i) job
+          then f (E.make p (V.Task j)))
+    | V.Task j as t,Succ ->
+      f @@ E.make t V.Sink
+    | V.Task j as t,Pred ->
+      Array.iteri workers ~f:(fun i worker ->
+          if sat_events rule worker jobs.(j)
+          then f (E.make (V.Person i) t))
+
+  let iter_succ_e = iter Succ
+  let iter_pred_e = iter Pred
+end
+
+module F = struct
+  type t = int
+  type label = unit
+  let max_capacity () = 1
+  let min_capacity () = 0
+  let flow () = min_capacity ()
+  let add = (+)
+  let sub = (-)
+  let zero = 0
+  let compare = Int.compare
+end
+
+module FFMF = Flow.Ford_Fulkerson(G)(F)
+
+let single_match fmatch events =
+  let f ev = fmatch (Value.pps () ev) in   
+  List.filter ~f (Set.to_list events)
+
+let match_right rule events = 
+  match single_match (Rule.match_field rule `Right) events with 
+  | [] -> None
+  | ms -> Some ([], ms)  
+
+let match_left rule events = 
+  match single_match (Rule.match_field rule `Left) events with 
+  | [] -> None
+  | ms -> Some (ms,[])  
+
+let match_both rule left right = 
+  let workers = Set.to_array left in      
+  let jobs = Set.to_array right in
+  let (flow,_) = FFMF.maxflow (rule, workers, jobs) G.V.Source G.V.Sink in
+  Array.foldi workers ~init:([],[])
+    ~f:(fun i (acc, acc') w ->   
+        match Array.findi jobs ~f:(fun j e ->
+            flow (G.E.make (G.V.Person i) (G.V.Task j)) <> 0) with
+        | None -> acc, acc' 
+        | Some (_,e) -> w :: acc, e :: acc') |> function
+  | [], [] -> None
+  | ms -> Some ms
+
+let match_events rule insn events events' =
+  match Rule.match_field rule `Insn insn with
+  | false -> None
+  | true -> 
+    let left = Set.diff events events' in
+    let right = Set.diff events' events in
+    match Rule.(is_empty (left rule)), Rule.(is_empty (right rule)) with
+    | true, true -> Some (Set.to_list events, Set.to_list events')
+    | true, _ -> match_right rule right
+    | _, true -> match_left rule left
+    | _ -> match_both rule left right
+
+let remove what from = 
+  let not_exists e = not (List.exists what ~f:(fun e' -> e = e')) in
+  Set.filter ~f:not_exists from 
+
+let remove_matched events events' (ms, ms') = 
+  remove ms events, remove ms' events'
+
+let denied rules insn events events' =   
+  let rec loop acc rules (evs,evs') = match rules with
+    | [] -> acc
+    | rule :: rls ->
+      match match_events rule insn evs evs' with
+      | None -> loop acc rls (evs,evs')
+      | Some matched -> 
+        let acc' = 
+          if Rule.action rule = Rule.skip then acc
+          else (rule, matched) :: acc in
+        remove_matched evs evs' matched |> 
+        loop acc' rls in
+  loop [] (List.rev rules) (events, events') 

--- a/lib/veri_policy.mli
+++ b/lib/veri_policy.mli
@@ -1,0 +1,25 @@
+open Core_kernel.Std
+open Bap.Std
+open Bap_traces.Std
+open Regular.Std
+
+type event = Trace.event
+type events = Value.Set.t
+type rule = Veri_rule.t 
+
+module Matched : sig
+  type t = event list * event list [@@deriving bin_io, compare, sexp]
+  include Regular with type t := t
+end
+
+type matched = Matched.t [@@deriving bin_io, compare, sexp]
+type t [@@deriving bin_io, compare, sexp]
+
+val empty : t
+val add : t -> rule -> t
+
+(** [match events rule insn left right] *)
+val match_events: rule -> string -> events -> events -> matched option
+
+(** [denied policy insn left right] *)
+val denied: t -> string -> events -> events -> (rule * matched) list

--- a/lib/veri_report.ml
+++ b/lib/veri_report.ml
@@ -1,82 +1,48 @@
 open Core_kernel.Std
 open Bap.Std
-open Bap_traces.Std 
+open Bap_traces.Std
 open Regular.Std
 
-module Names = String.Map
-
-type events = Value.Set.t [@@deriving bin_io, compare, sexp]
-type frame_diff = events * events [@@deriving bin_io, compare, sexp]
+type event = Trace.event [@@deriving bin_io, compare, sexp]
+type rule = Veri_rule.t [@@deriving bin_io, compare, sexp]
+type matched = Veri_policy.matched [@@deriving bin_io, compare, sexp]
 
 type t = {
-  frames : frame_diff list Names.t;
-  errors : Veri_error.t list;
-} [@@deriving bin_io, sexp]
+  bil  : bil;
+  insn : string;
+  code : string;
+  left : event list;
+  right: event list;
+  data : (rule * matched) list;
+} [@@deriving bin_io, compare, fields, sexp]
 
-let create () = { frames = Names.empty; errors = []; }
-
-let update t name diff =
-  let frames = 
-    Map.change t.frames name
-      (function 
-        | None -> Some [diff]
-        | Some diffs -> Some (diff :: diffs)) in
-  {t with frames}
-
-let frames {frames} = Map.to_alist frames
-let errors t = t.errors
-
-let notify t er = {t with errors = er :: t.errors }
-
-let errors_count t ~f = List.count t.errors ~f
-
-let overloaded_count t = errors_count t 
-    ~f:(function 
-        | `Overloaded_chunk -> true 
-        | _ -> false)
-
-let damaged_count t = errors_count t 
-    ~f:(function 
-        | `Damaged_chunk _ -> true 
-        | _ -> false)
-
-let disasm_count t =  errors_count t 
-    ~f:(function 
-        | `Disasm_error _ -> true 
-        | _ -> false)
-    
-let lifter_count t =  errors_count t 
-    ~f:(function 
-        | `Lifter_error _ -> true 
-        | _ -> false)
-
-type s = t [@@deriving bin_io, compare, sexp]
+let create = Fields.create
 
 include Regular.Make(struct
-    type t = s [@@deriving bin_io, compare, sexp]
+    type nonrec t = t [@@deriving bin_io, compare, sexp]
+
     let compare = compare
     let hash = Hashtbl.hash
-
-    let pp_ev fmt ev = Format.fprintf fmt "%a; " Value.pp ev
-    let pp_events fmt evs = Set.iter evs ~f:(pp_ev fmt)
-        
-    let pp_diff fmt (left, right) = 
-      Format.fprintf fmt "left: %a\nright: %a\n"  
-        pp_events left pp_events right
-
-    let pp_frames fmt (name, diffs) = 
-      let open Format in
-      fprintf fmt "%s\n" name;
-      List.iter ~f:(fun d -> pp_diff fmt d;) diffs
-      
-    let pp fmt t =
-      List.iter ~f:(pp_frames fmt) (frames t);
-      Format.fprintf fmt "errors statistic: \
-        overloaded chunks: %d; damaged chunks: %d; \
-        disasm errors: %d; lifter errors: %d\n"  
-        (overloaded_count t) (damaged_count t) (disasm_count t)
-        (lifter_count t) 
-
-    let module_name = Some "Veri_Report"
+    let module_name = Some "Veri.Report"
     let version = "0.1"
+
+    let pp_code fmt s =
+      let pp fmt s =
+        String.iter ~f:(fun c -> Format.fprintf fmt "%X " (Char.to_int c)) s in
+      Format.fprintf fmt "@[<h>%a@]" pp s
+
+    let pp_evs fmt evs =
+      List.iter ~f:(fun ev ->
+          Format.(fprintf std_formatter "%a; " Value.pp ev)) evs
+
+    let pp_data fmt (rule, matched) =
+      let open Veri_policy in
+      Format.fprintf fmt "%a\n%a" Veri_rule.pp rule Matched.pp matched
+
+    let pp fmt t =
+      Format.fprintf fmt "@[<v>%s %a@,left: %a@,right: %a@,%a@]@."
+        t.insn pp_code t.code pp_evs t.left pp_evs t.right Bil.pp t.bil;
+      List.iter ~f:(pp_data fmt) t.data;
+      Format.print_newline ()
+
   end)

--- a/lib/veri_report.mli
+++ b/lib/veri_report.mli
@@ -3,18 +3,24 @@ open Bap.Std
 open Bap_traces.Std
 open Regular.Std
 
+type event = Trace.event [@@deriving bin_io, compare, sexp]
+type matched = Veri_policy.matched [@@deriving bin_io, compare, sexp]
+type rule = Veri_rule.t [@@deriving bin_io, compare, sexp]
+
 type t [@@deriving bin_io, sexp]
-
-type events = Value.Set.t
-
-(** events that occurred only on the left and only on the right *)
-type frame_diff = events * events [@@deriving bin_io, compare, sexp]
-
-val create: unit -> t
-val update: t -> string -> frame_diff -> t
-val frames: t -> (string * frame_diff list) list
-val notify: t -> Veri_error.t -> t
-val errors: t -> Veri_error.t list
-
 include Regular with type t := t
 
+val create :
+  bil:Bap.Std.bil ->
+  insn:string ->
+  code:string ->
+  left:event list ->
+  right:event list ->
+  data:(rule * matched) list -> t
+
+val bil  : t -> bil
+val code : t -> string
+val insn : t -> string
+val left : t -> Trace.event list
+val right: t -> Trace.event list
+val data : t -> (Veri_policy.rule * Veri_policy.matched) list

--- a/lib/veri_rule.ml
+++ b/lib/veri_rule.ml
@@ -1,0 +1,151 @@
+open Core_kernel.Std
+open Regular.Std
+
+type trial = Pcre.regexp
+
+let empty = ""
+let trial_exn s = Pcre.regexp ~flags:[`ANCHORED] s
+let er s = Error (Error.of_string s) 
+
+module Action = struct
+  type t = Skip | Deny [@@deriving bin_io, compare, sexp]
+  let skip = Skip
+  let deny = Deny
+
+  let to_string = function
+    | Skip -> "SKIP"
+    | Deny -> "DENY"
+
+  let of_string_err = function 
+    | "SKIP" -> Ok Skip
+    | "DENY" -> Ok Deny
+    | s -> er (Printf.sprintf "only SKIP | DENY actions should be used: %s" s)
+end
+
+module Field = struct
+  type t = trial * string
+
+  let create_exn s = trial_exn s, s
+
+  let create_err s =
+    try
+      Ok (create_exn s)
+    with Pcre.Error _ -> 
+      let s = Printf.sprintf "error in field %s" s in
+      Error (Error.of_string s)
+
+  let is_empty f = snd f = empty
+end
+
+type action = Action.t [@@deriving bin_io, compare, sexp] 
+type field = Field.t
+
+type t = {
+  action : action;
+  insn   : field;
+  both   : field;
+  left   : field;
+  right  : field;
+} [@@deriving fields]
+
+exception Bad_field of string
+
+let skip = Action.skip
+let deny = Action.deny
+let is_empty = Field.is_empty
+
+let contains_backreference = 
+  let rex = Pcre.regexp "\\\\[1-9]" in
+  fun s -> Pcre.pmatch ~rex s
+
+let right_field s = 
+  if contains_backreference s then
+    Ok (trial_exn empty, s)
+  else Field.create_err s
+
+let create ?insn ?left ?right action =
+  let open Result in
+  let of_opt = Option.value_map ~default:empty ~f:ident in 
+  let both = String.concat ~sep:" " [of_opt left; of_opt right] in    
+  Field.create_err (of_opt insn) >>= fun insn ->
+  Field.create_err both >>= fun both ->
+  Field.create_err (of_opt left) >>= fun left ->
+  right_field (of_opt right) >>= fun right ->    
+  Ok ({action; insn; both; left; right;})
+
+let create_exn ?insn ?left ?right action = 
+  match create ?insn ?left ?right action with 
+  | Ok r -> r
+  | Error s -> raise (Bad_field (Error.to_string_hum s))
+
+let match_field t field s = 
+  let field' = match field with
+    | `Insn -> t.insn
+    | `Both -> t.both
+    | `Left -> t.left
+    | `Right -> t.right in
+  Pcre.pmatch ~rex:(fst field') s
+  
+module S = struct
+
+  type nonrec t = t
+
+  let to_string t = 
+    let contains_space s = String.exists ~f:(fun c -> c = ' ') s in
+    let of_field f = 
+      if Field.is_empty f then "''"
+      else if contains_space (snd f) then Printf.sprintf "'%s'" (snd f)
+      else snd f in
+    Printf.sprintf "%s %s %s %s" (Action.to_string t.action) 
+      (of_field t.insn) (of_field t.left) (of_field t.right)
+
+  let rex = Pcre.regexp "'.*?'|\".*?\"|\\S+"
+  let is_quote c = c = '\"' || c = '\''
+  let unquote s = String.strip ~drop:is_quote s
+
+  (** Not_found could be raised here  *)
+  let fields_exn str = 
+    Pcre.exec_all ~rex str |>
+    Array.fold ~init:[] ~f:(fun acc ar ->
+        let subs = Pcre.get_substrings ar in
+        acc @ Array.to_list subs) |>
+    List.map ~f:unquote
+
+  let fields_opt str = 
+    try
+      match fields_exn str with 
+      | [action; insn; left; right] -> Some (action, insn, left, right)
+      | _ -> None
+    with Not_found -> None
+
+  let fields_err str = 
+    match fields_opt str with
+    | Some fields -> Ok fields
+    | None -> 
+      er (Printf.sprintf "String %s doesn't match to rule grammar" str)
+
+  let of_string_err s = 
+    let open Or_error in
+    fields_err s >>= fun (action, insn, left, right) ->
+    Action.of_string_err action >>= fun action' ->
+    create ~insn ~left ~right action'
+
+  let of_string str = ok_exn (of_string_err str)
+
+end
+
+let of_string_err = S.of_string_err
+
+include Sexpable.Of_stringable(S)
+include Binable.Of_stringable(S)
+include (S : Stringable with type t := t)
+
+include Regular.Make(struct
+    type nonrec t = t [@@deriving bin_io, compare, sexp]
+    let compare = compare
+    let hash = Hashtbl.hash
+    let module_name = Some "Veri_rule"
+    let version = "0.1"
+
+    let pp fmt t = Format.fprintf fmt "%s" (to_string t)
+  end)

--- a/lib/veri_rule.mli
+++ b/lib/veri_rule.mli
@@ -1,0 +1,45 @@
+(** rule = ACTION : INSN : EVENT : EVENT  *)
+
+open Core_kernel.Std
+open Regular.Std
+
+type t [@@deriving bin_io, compare, sexp]
+type action [@@deriving bin_io, compare, sexp]
+type field
+include Regular with type t := t
+
+(** [create ~insn ~left ~right action] - returns a rule,
+    if all of fields {insn, left, right} either contains 
+    correct regular expression, either plain string, either
+    are an empty strings. If some field is not given, it's 
+    assumed that an empty string fits well for this field. *)
+val create :
+  ?insn:string -> ?left:string -> ?right:string -> action -> t Or_error.t
+
+exception Bad_field of string
+
+(** [create_exn ~insn ~left ~right action] - the same as above, but raises
+    Bad_field exception if fields contains errors in regular expressions *)
+val create_exn : ?insn:string -> ?left:string -> ?right:string -> action -> t
+
+(** [of_string_err str] - return a rule, if string contains exactly 4 fields:
+    - action (with only two possible values: SKIP | DENY)
+    - instruction name or correct regular expression
+    - one of the following:
+       correct regular expression for left part and empty string for right part;
+       empty string for left part and correct regular expression for right part;
+       correct regular expression for both left and right parts. *)
+val of_string_err : string -> t Or_error.t
+
+val skip : action
+val deny : action
+
+val action : t -> action
+val insn   : t -> field
+val left   : t -> field
+val right  : t -> field
+
+val is_empty : field -> bool
+
+(** [match_field t field str] - match a given string with a field. *)
+val match_field: t -> [`Insn | `Left | `Right | `Both] -> string -> bool

--- a/lib/veri_stat.ml
+++ b/lib/veri_stat.ml
@@ -1,0 +1,215 @@
+open Core_kernel.Std
+open Regular.Std
+
+module Calls = String.Map
+
+type ok_er = int * int [@@deriving bin_io, compare, sexp]
+
+type t = {
+  calls : ok_er Calls.t;
+  errors: Veri_error.t list;
+} [@@deriving bin_io, compare, sexp]
+
+type stat = t [@@deriving bin_io, compare, sexp]
+
+let empty = { calls = Calls.empty; errors = []; }
+let errors t = t.errors
+let notify t er = {t with errors = er :: t.errors }
+
+let update t name ~ok ~er = 
+  {t with 
+   calls =
+     Map.change t.calls name
+       (function 
+         | None -> Some (ok, er)
+         | Some (ok',er') -> Some (ok + ok', er + er')) } 
+
+let failbil t name = update t name ~ok:0 ~er:1
+let success t name = update t name ~ok:1 ~er:0
+
+module Abs = struct
+
+  type nonrec t = t -> int
+
+  let fold_calls {calls} f = Map.fold ~f ~init:0 calls
+
+  let errors_count t = 
+    let rec loop ((ovr, dmg, undis, misl) as acc) = function
+      | [] -> acc
+      | hd :: tl -> match hd with 
+        | `Overloaded_chunk -> loop (ovr + 1, dmg, undis, misl) tl
+        | `Damaged_chunk  _ -> loop (ovr, dmg + 1, undis, misl) tl
+        | `Disasm_error   _ -> loop (ovr, dmg, undis + 1, misl) tl
+        | `Lifter_error   _ -> loop (ovr, dmg, undis, misl + 1) tl in
+    loop (0,0,0,0) t.errors
+
+  let overloaded  t = let x,_,_,_ = errors_count t in x
+  let damaged     t = let _,x,_,_ = errors_count t in x
+  let undisasmed  t = let _,_,x,_ = errors_count t in x
+  let mislifted   t = let _,_,_,x = errors_count t in x
+  let successed   t = fold_calls t (fun ~key ~data cnt -> cnt + fst data)
+  let misexecuted t = fold_calls t (fun ~key ~data cnt -> cnt + snd data)
+
+  let abs_successed t = 
+    fold_calls t (fun ~key ~data cnt ->
+        if snd data <> 0 then cnt
+        else cnt + fst data)
+      
+  let abs_misexecuted t = 
+    fold_calls t (fun ~key ~data cnt ->   
+      if fst data <> 0 then cnt 
+      else cnt + snd data)
+
+  let total t = 
+    List.length t.errors + 
+    fold_calls t (fun ~key ~data cnt -> cnt + fst data + snd data)
+
+end
+
+module Rel = struct
+  type t = ?as_percents:bool -> stat -> float
+
+  let apply f b t  = 
+    let r = float (f t) /. float (Abs.total t) in
+    if b then r *. 100.0
+    else r
+
+  let ( @@ ) = apply
+
+  let successed       ?(as_percents=false) = Abs.successed @@ as_percents
+  let abs_successed   ?(as_percents=false) = Abs.abs_successed @@ as_percents
+  let misexecuted     ?(as_percents=false) = Abs.misexecuted @@ as_percents
+  let abs_misexecuted ?(as_percents=false) = Abs.abs_misexecuted @@ as_percents
+  let overloaded      ?(as_percents=false) = Abs.overloaded @@ as_percents
+  let damaged         ?(as_percents=false) = Abs.damaged @@ as_percents
+  let undisasmed      ?(as_percents=false) = Abs.undisasmed @@ as_percents
+  let mislifted       ?(as_percents=false) = Abs.mislifted @@ as_percents
+end
+
+module Names = struct
+
+  type nonrec t = t -> string list
+
+  let fold_calls ~condition t =
+    Map.fold ~f:(fun ~key ~data names -> 
+        if condition data then Set.add names key
+        else names) ~init:String.Set.empty t.calls |>
+    Set.to_list
+
+  let successed = fold_calls ~condition:(fun data -> fst data <> 0)
+  let abs_successed = fold_calls ~condition:(fun data -> snd data = 0)
+  let misexecuted = fold_calls ~condition:(fun data -> snd data <> 0)
+  let abs_misexecuted = fold_calls ~condition:(fun data -> fst data = 0)
+
+  let mislifted t = 
+    List.fold_left ~init:String.Set.empty 
+      ~f:(fun names errs ->
+          match errs with 
+          | `Lifter_error (insn,_) -> Set.add names insn
+          | _ -> names) t.errors |>
+    Set.to_list
+end
+
+let print_table fmt info data = 
+  let open Textutils.Std in
+  let open Ascii_table in
+  let cols = 
+    List.fold ~f:(fun acc (name, f) -> 
+        (Column.create name f)::acc) ~init:[] info |> List.rev in
+  Format.fprintf fmt "%s"
+    (to_string ~bars:`Ascii ~display:Display.short_box cols data)
+
+module Summary = struct
+
+  type nonrec t = t [@@deriving bin_io, compare, sexp]
+
+  type p = {
+    name: string;
+    rel : float;
+    abs : int;
+  } [@@deriving bin_io, sexp, compare]
+
+  let of_stat s =
+    let make name abs rel = {name; abs; rel;} in
+    if Abs.total s = 0 then []
+    else
+      let as_percents = true in
+      [ make "overloaded"  (Abs.overloaded s)  (Rel.overloaded ~as_percents s);
+        make "undisasmed"  (Abs.undisasmed s)  (Rel.undisasmed ~as_percents s);
+        make "misexecuted" (Abs.misexecuted s) (Rel.misexecuted ~as_percents s);
+        make "mislifted"   (Abs.mislifted s)   (Rel.mislifted ~as_percents s);
+        make "damaged"     (Abs.damaged s)     (Rel.damaged ~as_percents s);
+        make "successed"   (Abs.successed s)   (Rel.successed ~as_percents s);]
+
+  let pp fmt t = match of_stat t with
+    | [] -> Format.fprintf fmt "summary is unavailable\n"
+    | ps ->
+      print_table fmt 
+        ["", (fun x -> x.name);
+         "rel", (fun x -> Printf.sprintf "%.2f%%" x.rel);
+         "abs",  (fun x -> Printf.sprintf "%d" x.abs);]
+        ps
+
+end
+
+let merge ts =
+  let (+) s s' =
+    let errors = s.errors @ s'.errors in
+    let calls = Map.fold ~init:s.calls s'.calls
+        ~f:(fun ~key ~data calls ->
+            Map.change calls key ~f:(function
+                | None -> Some data
+                | Some (ok,er) -> Some (fst data + ok, snd data + er))) in
+    {errors; calls} in
+  List.fold ~f:(+) ~init:empty ts
+
+let pp_summary = Summary.pp
+
+include Regular.Make(struct
+    type nonrec t = t [@@deriving bin_io, compare, sexp]
+    let compare = compare
+    let hash = Hashtbl.hash
+    let module_name = Some "Veri_stat"
+    let version = "0.1"
+
+    let pp_misexecuted fmt = function
+      | [] -> ()
+      | mis -> 
+        Format.fprintf fmt "misexecuted \n";
+        print_table fmt 
+          [ "instruction", fst;
+            "failed", (fun (_, (_,er)) -> Printf.sprintf "%d" er);
+            "successful", (fun (_, (ok,_)) -> Printf.sprintf "%d" ok); ] 
+          mis
+
+    let pp_mislifted fmt names = 
+      let max_row_len = 10 in
+      let max_col_cnt = 5 in
+      match names with 
+      | [] -> ()
+      | names when List.length names <= max_row_len ->
+        let names' = "mislifted:" :: names in
+        List.iter ~f:(Format.fprintf fmt "%s ") names';
+        Format.print_newline ()
+      | names ->
+        let rows, row, _ = List.fold ~init:([], [], 0)
+            ~f:(fun (acc, row, i) name ->
+                if i < max_col_cnt then acc, name :: row, i + 1
+                else row :: acc, name :: [], 1) names in
+        let gaps = Array.create ~len:(max_col_cnt - List.length row) "-----" in
+        let last = row @ Array.to_list gaps in
+        let rows = List.rev (last :: rows) in
+        let make_col i = "mislifted", (fun row -> List.nth_exn row i) in
+        let cols = [
+          make_col 0; make_col 1; make_col 2; make_col 3; make_col 4; ] in
+        print_table fmt cols rows
+
+    let pp fmt t = 
+      let misexec = 
+        List.filter ~f:(fun (_,(_,er)) -> er <> 0) (Map.to_alist t.calls) in
+      let mislift = Names.mislifted t in
+      Format.fprintf fmt "%a\n%a\n"
+        pp_misexecuted misexec pp_mislifted mislift
+
+  end)
+

--- a/lib/veri_stat.mli
+++ b/lib/veri_stat.mli
@@ -1,0 +1,66 @@
+
+open Regular.Std
+type t [@@deriving bin_io, sexp]
+type stat = t [@@deriving bin_io, sexp]
+
+val empty : t
+val merge : t list -> t
+val notify : t -> Veri_error.t -> t
+val failbil : t -> string -> t
+val success : t -> string -> t
+
+val pp_summary: Format.formatter -> t -> unit
+
+include Regular with type t := t
+
+(** Terms:
+    successed       - instructions, that were successfuly lifted and evaluted
+                      without any divergence from trace at least once (or more);
+    misexecuted     - instructions, that were successfuly lifted and evaluted
+                      with divergence from trace at least once (or more);
+    abs_successed   - the same as successed but no divergences has occured
+    abs_misexecuted - the same as misexecuted but haven't any successfully
+                      matches with trace at all;
+    mislifted       - instructions, that weren't recognized by lifter;
+    overloaded      - chunks that contains more that one instruction;
+    damaged         - chunks that failed to be represented as memory;
+    undisasmed      - chunks that were represented as memory, but failed to
+                      be disasmed;
+    total           - whole count of cases above *)
+
+(** absolute counts  *)
+module Abs : sig
+  type t = stat -> int
+  val successed       : t
+  val abs_successed   : t
+  val misexecuted     : t
+  val abs_misexecuted : t
+  val overloaded      : t
+  val damaged         : t
+  val undisasmed      : t 
+  val mislifted       : t
+  val total           : t
+end
+
+(** relative to total count *)
+module Rel : sig
+  type t = ?as_percents:bool -> stat -> float
+  val successed       : t
+  val abs_successed   : t
+  val misexecuted     : t
+  val abs_misexecuted : t
+  val overloaded      : t
+  val damaged         : t
+  val undisasmed      : t
+  val mislifted       : t
+end
+
+(** instruction names  *)
+module Names : sig
+  type t = stat -> string list
+  val successed       : t
+  val abs_successed   : t
+  val misexecuted     : t
+  val abs_misexecuted : t
+  val mislifted       : t
+end

--- a/lib/veri_traci.ml
+++ b/lib/veri_traci.ml
@@ -12,12 +12,12 @@ let stub = fun _ -> SM.return ()
 class context trace =
  object(self:'s)
     inherit Bili.context
-    val events = Trace.events trace 
+    val events = Trace.read_events trace 
     method next_event = match Seq.next events with
       | None -> None 
       | Some (ev,evs) -> Some ({<events = evs; >}, ev)
 
-    method with_events trace = {<events = Trace.events trace >}
+    method with_events trace = {<events = Trace.read_events trace >}
   end
 
 let data_size mv = 

--- a/rules/x86
+++ b/rules/x86
@@ -1,0 +1,17 @@
+# insn contains a conditional branch. As a result, in tracer, 
+# if a condition is not satisfied then the same value 
+# is written (the same as was read).
+SKIP CMPXCHG.* '.* <= .*' ''
+
+# LEAVE insn has additional read from RSP in our tracer
+SKIP LEAVE.* 'RSP => .*' ''
+
+# Our flags reads(writes) should be subset of tracer 
+# reads(writes). But writes should be with same value
+SKIP .* '.F => .*' '' 
+DENY .* '(.F) <= .*' '\1 <= .*'
+SKIP .* '.F <= .*' ''
+
+# Last rules means that every event should has a pair
+DENY .* '.*' ''
+DENY .* '' '.*'

--- a/rules/x86_no_errors
+++ b/rules/x86_no_errors
@@ -1,0 +1,46 @@
+# we completle ignore the following because bil is either empty, 
+# either contains unknown expressions or special statements
+SKIP NOOP. '' '' 
+SKIP RDTSC '' ''
+SKIP SYSCALL.* '' ''
+SKIP CPUID '' ''
+SKIP XGETBV '' ''
+
+#this one doesn't perform any write operation in our lifter
+#SKIP FNSTCW16m '' ''
+
+#differences in ZF flag writing
+SKIP TZCNT64rr 'ZF <= .*' 'ZF <= .*'
+
+# SAR is suspected to be broken in our lifter, because of different 
+# results with tracer
+SKIP SAR.* '' ''
+
+# XOR is suspected to be broken, because in case of same operands,
+# e.g. RAX and RAX, it reads nothing, just write zero to destination
+SKIP XOR.* '.* => .*' ''
+
+# There are a wrong flags reads in our lifter. 
+SKIP SH(L|R).* '' '.F => .*'
+
+# CMOV in our lifter works a bit unstrict. It reads and writes the same value
+# if condition wasn't succeded.
+SKIP CMOV.* '' '.*'
+
+# insn contains a conditional branch. As a result, in tracer, 
+# if a condition is not satisfied then the same value 
+# is written (the same as was read).
+SKIP CMPXCHG.* '.* <= .*' ''
+
+# LEAVE insn has additional read from RSP in our tracer
+SKIP LEAVE.* 'RSP => .*' ''
+
+# Our flags reads(writes) should be subset of tracer 
+# reads(writes). But writes should be with same value
+SKIP .* '.F => .*' '' 
+DENY .* '(.F) <= .*' '\1 <= .*'
+SKIP .* '.F <= .*' ''
+
+# Last rules means that every event should has a pair
+DENY .* '.*' ''
+DENY .* '' '.*'

--- a/src/veri_main.ml
+++ b/src/veri_main.ml
@@ -2,7 +2,8 @@ open Core_kernel.Std
 open Bap.Std
 open Bap_traces.Std
 open Bap_plugins.Std
-open Cmdliner
+open Bap_future.Std
+open Veri_policy
 
 module Dis = Disasm_expert.Basic
 
@@ -13,53 +14,199 @@ let () =
     Printf.eprintf "failed to load plugin from %s: %s" 
       path (Error.to_string_hum er)
 
-let string_of_error = function
-  | `Protocol_error er -> 
-    Printf.sprintf "protocol error: %s" 
-      (Info.to_string_hum (Error.to_info er))
-  | `System_error er -> 
-    Printf.sprintf "system error: %s" (Unix.error_message er)
-  | `No_provider -> "no provider"
-  | `Ambiguous_uri -> "ambiguous uri"
+module Veri_options = struct
+  type t = {
+    rules : string option;
+    show_errs : bool;
+    show_stat : bool;
+    path  : string;
+    out   : string option;
+  } [@@deriving fields]
+end
 
-let eval file f = 
-  let uri = Uri.of_string ("file://" ^ file) in  
-  match Trace.load uri with
-  | Error er -> 
-    Printf.eprintf "error during loading trace: %s\n" (string_of_error er)
-  | Ok trace ->
-    match Dict.find (Trace.meta trace) Meta.arch with
-    | Some arch -> f arch trace
-    | None -> Printf.eprintf "trace of unknown arch\n"
+module type Opts = sig
+  val options : Veri_options.t
+end
 
-let run file =
-  let f arch trace = 
-    let report = 
-      Dis.with_disasm ~backend:"llvm" (Arch.to_string arch) ~f:(fun dis ->
-          let dis = Dis.store_asm dis |> Dis.store_kinds in          
-          let report = Veri_report.create () in
-          let ctxt = new Veri.context report trace in
-          let veri  = new Veri.t arch dis (fun _ -> true) in
-          let ctxt' = 
-            Monad.State.exec (veri#eval_trace trace) ctxt in
-          Ok ctxt'#report) in
-    match report with
+module Program (O : Opts) = struct
+  open Veri_options
+  open O
+
+  let read_rules fname = 
+    let comments = "#" in
+    let is_sensible s = 
+      s <> "" && not (String.is_prefix ~prefix:comments s) in
+    let inc = In_channel.create fname in
+    let strs = In_channel.input_lines inc in
+    In_channel.close inc;
+    List.map ~f:String.strip strs 
+    |> List.filter ~f:is_sensible
+    |> List.map ~f:Veri_rule.of_string_err |>
+    List.filter_map ~f:(function 
+        | Ok r -> Some r
+        | Error er -> 
+          Format.(fprintf std_formatter "%s\n" (Error.to_string_hum er));
+          None)
+
+  let string_of_error = function
+    | `Protocol_error er -> 
+      Printf.sprintf "protocol error: %s" 
+        (Info.to_string_hum (Error.to_info er))
+    | `System_error er -> 
+      Printf.sprintf "system error: %s" (Unix.error_message er)
+    | `No_provider -> "no provider"
+    | `Ambiguous_uri -> "ambiguous uri"
+
+  let default_policy = 
+    let open Veri_rule in  
+    let p = Veri_policy.(add empty (create_exn ~insn:".*" ~left:".*" deny)) in
+    Veri_policy.add p (create_exn ~insn:".*" ~right:".*" deny)
+
+  let make_policy = function
+    | None -> default_policy
+    | Some file -> 
+      read_rules file |>
+      List.fold ~f:Veri_policy.add ~init:Veri_policy.empty
+
+  let errors_stream s = 
+    let pp_result fmt report  = 
+      Format.fprintf fmt "%a" Veri_report.pp report;
+      Format.print_flush () in
+    ignore(Stream.subscribe s (pp_result Format.std_formatter))
+  
+  let is_interesting ev = not (Value.is Event.context_switch ev)
+  
+  let eval_file file policy  = 
+    let mk_er s = Error (Error.of_string s) in
+    let uri = Uri.of_string ("file:" ^ file) in
+    match Trace.load uri with
     | Error er -> 
-      let inf = Error.to_string_hum er in
-      Printf.eprintf "error in verification: %s" inf
-    | Ok report ->
-      Veri_report.pp Format.std_formatter report in
-  eval file f
+      Printf.sprintf "error during loading trace: %s\n" (string_of_error er) |>
+      mk_er 
+    | Ok trace ->
+      match Dict.find (Trace.meta trace) Meta.arch with
+      | None -> mk_er "trace of unknown arch"
+      | Some arch ->
+        Dis.with_disasm ~backend:"llvm" (Arch.to_string arch) ~f:(fun dis ->
+            let dis = Dis.store_asm dis |> Dis.store_kinds in
+            let stat = Veri_stat.empty in
+            let ctxt = new Veri.context stat policy trace in
+            let veri = new Veri.t arch dis is_interesting in
+            if options.show_errs then errors_stream ctxt#reports;
+            let ctxt' = Monad.State.exec (veri#eval_trace trace) ctxt in
+            Ok ctxt'#stat)
 
-let filename = 
-  let doc = "Input filename" in 
-  Arg.(required & pos 0 (some non_dir_file) None & info [] ~doc ~docv:"FILE") 
+  let read_dir path = 
+    let dir = Unix.opendir path in
+    let fullpath file = String.concat ~sep:"/" [path; file] in
+    let is_trace file = Filename.check_suffix file ".frames" in
+    let next () = 
+      try 
+        Some (Unix.readdir dir)
+      with End_of_file -> None in
+    let rec folddir acc = 
+      match next () with
+      | Some file -> 
+        if is_trace file then folddir (fullpath file :: acc) 
+        else folddir acc 
+      | None -> acc in
+    let files = folddir [] in
+    Unix.closedir dir;
+    files
 
-let info =
-  let doc = "Bil verification tool" in
-  let man = [] in
-  Term.info "veri" ~doc ~man
+  let main () =   
+    let files = 
+      if Sys.is_directory options.path then (read_dir options.path)
+      else [options.path] in
+    let policy = make_policy options.rules in
+    let eval stats file = 
+      Format.(fprintf std_formatter "%s@." file);
+      match eval_file file policy with
+      | Error er -> 
+        Error.to_string_hum er |>
+        Printf.eprintf "error in verification: %s";
+        stats
+      | Ok stat' -> (Filename.basename file, stat') :: stats in
+    let stats = List.fold ~init:[] ~f:eval files in
+    let stat = Veri_stat.merge (List.map ~f:snd stats) in
+    if options.show_stat then
+      Veri_stat.pp Format.std_formatter stat;
+    Format.(fprintf std_formatter "%a\n" Veri_stat.pp_summary stat);
+    match options.out with
+    | None -> ()
+    | Some out -> Veri_out.output stats out
 
-let run_t = Term.(const run $ filename)
+end
 
-let () = match Term.eval (run_t, info) with `Error _ -> exit 1 | _ -> exit 0
+module Command = struct
+
+  open Cmdliner
+
+  let filename = 
+    let doc = 
+      "Input file with extension .frames of directory with .frames files" in 
+    Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"FILE | DIR")
+
+  let output =
+    let doc = "File to output results" in
+    Arg.(value & opt (some string) None & info ["output"] ~docv:"FILE" ~doc)
+      
+  let rules =
+    let doc = "File with policy description" in
+    Arg.(value & opt (some non_dir_file) None & info ["rules"] ~docv:"FILE" ~doc)
+
+  let make_flag ~doc ~name = Arg.(value & flag & info [name] ~doc)
+
+  let show_errors = 
+    make_flag ~name:"show-errors" 
+      ~doc:"Show detailed information about BIL errors"
+
+  let show_stat = make_flag ~name:"show-stat" ~doc:"Show verification statistic"
+
+  let info =
+    let doc = "Bil verification tool" in
+    let man = [
+      `S "DESCRIPTION";
+      `P "Veri is a BIL verification tool and intend to verify BAP lifters
+          and to find errors.";
+    ] in
+    Term.info "veri" ~doc ~man
+
+  let create a b c d e = Veri_options.Fields.create a b c d e 
+
+  let run_t = 
+    Term.(const create $ rules $ show_errors $ show_stat $ filename $ output)
+
+  let filter_argv argv = 
+    let known_passes = Project.passes () |> List.map ~f:Project.Pass.name in
+    let known_plugins =  Plugins.list () |> List.map ~f:Plugin.name in
+    let known_names = known_passes @ known_plugins in
+    let prefixes = List.map known_names  ~f:(fun name -> "--" ^ name) in
+    let is_prefix str prefix = String.is_prefix ~prefix str in
+    let is_others opt = 
+      is_prefix opt "--" && List.exists ~f:(fun p -> is_prefix opt p) prefixes in
+    List.fold ~init:([], false) ~f:(fun (acc, drop) opt -> 
+        if drop then acc, false
+        else
+        if is_others opt then acc, not (String.mem opt '=') 
+        else opt :: acc, false) (Array.to_list argv) |> 
+    fst |> List.rev |> Array.of_list
+
+  let parse argv = 
+    let argv = filter_argv argv in
+    match Term.eval ~argv (run_t, info) ~catch:false with
+    | `Ok opts -> opts
+    | `Error `Parse -> exit 64
+    | `Error _ -> exit 2
+    | _ -> exit 1
+
+end
+
+let start options =
+  let module Program = Program(struct
+      let options = options
+    end) in
+  Program.main ()
+
+let () = start (Command.parse Sys.argv)
+

--- a/src/veri_out.ml
+++ b/src/veri_out.ml
@@ -1,0 +1,39 @@
+open Core_kernel.Std
+open Textutils.Std 
+open Text_block
+
+module Abs = Veri_stat.Abs
+module Rel = Veri_stat.Rel
+
+let make_iota max = 
+  let rec make acc n = 
+    if n < 0 then acc
+    else make (n :: acc) (n - 1) in
+  make [] (max - 1)
+
+let make_col title to_string vals = 
+  vcat ~align:`Center (text title :: List.map ~f:(fun x -> text (to_string x)) vals)
+
+let texts_col title vals = make_col title ident vals
+let intgr_col title vals = make_col title (Printf.sprintf "%d") vals
+let float_col title vals = make_col title (Printf.sprintf "%.2f") vals
+
+let output stats path = 
+  let of_stats f = List.map ~f stats in
+  let of_stats' f = List.map ~f:(fun x -> f (snd x)) stats in
+  let out = Out_channel.create path in
+  let cnter = intgr_col "#" (make_iota (List.length stats)) in
+  let names = texts_col "file" (of_stats fst) in
+  let total = intgr_col "total" (of_stats' Abs.total) in
+  let as_percents = true in
+  let prcnt = List.map
+      ~f:(fun (name, f) -> float_col name (of_stats' f))
+             [ "successed, %",   Rel.successed ~as_percents; 
+               "misexecuted, %", Rel.misexecuted ~as_percents;
+               "overloaded, %",  Rel.overloaded ~as_percents;
+               "damaged, %",     Rel.damaged ~as_percents;
+               "undisasmed, %",  Rel.undisasmed ~as_percents;
+               "mislifted, %",   Rel.mislifted ~as_percents; ] in
+  let tab = hcat ~sep:(text "  |  ") ([cnter; names; total] @ prcnt) in
+  Out_channel.output_string out (render tab);
+  Out_channel.close out

--- a/tests/run_pin.sh
+++ b/tests/run_pin.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+bpt=$HOME/factory/bap-pintraces/obj-intel64/bpt.so
+
+files=$(ls $1 | grep gcc | grep O0)
+ 
+for file in $files
+do
+    echo $file
+    input="$1$file"
+    basename=${file##*/}
+    output="$2$basename.frames"
+    pin -injection child -t $bpt -o $output -- $input --help 1 > /dev/null
+done
+

--- a/tests/run_tests.ml
+++ b/tests/run_tests.ml
@@ -2,15 +2,20 @@ open Core_kernel.Std
 open Bap_plugins.Std
 open OUnit2
 
-let suite () =
-  "Bap-veri" >::: [ Veri_test.suite (); ]
-
 let load_plugins () =
   match Plugins.load () |> Result.all with
   | Ok plugins -> ()
   | Error (p,e)->
     assert_string ("failed to load plugin from " ^ p ^ ": " ^
                    Error.to_string_hum e)
+
+let suite () =
+  "Bap-veri" >::: [ 
+    Veri_test.suite ();
+    Veri_policy_test.suite ();
+    Veri_rule_test.suite ();
+    Veri_stat_test.suite ();
+  ]
 
 let () = 
   load_plugins ();

--- a/tests/run_veri.sh
+++ b/tests/run_veri.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+frames=$(find $1 -name "*.frames")
+for file in $frames
+do    
+    res=$(./bil-verification/veri_main.native --show-stat --rules bil-verification/rules/x86 $file)
+    echo "$file : $res"
+done

--- a/tests/veri_policy_test.ml
+++ b/tests/veri_policy_test.ml
@@ -1,0 +1,43 @@
+open Core_kernel.Std
+open OUnit2
+open Bap.Std
+open Bap_future.Std
+open Bap_traces.Std
+open Event
+
+module Policy = Veri_policy
+module Rule = Veri_rule
+module Events = Value.Set
+
+(** this implies, that right reads should be subset of left reads and
+    right writes should be subset of left writes *)
+let rule_with_skip = Rule.create_exn Rule.skip ~left:".F => .*"
+let rule_with_deny = Rule.create_exn Rule.deny ~left:"(.F) <= .*" ~right:"\\1 <= .*"
+let rule_with_skip' = Rule.create_exn Rule.skip ~left:".F <= .*"
+let policy = 
+  let add rule policy = Policy.add policy rule in
+  add rule_with_skip Policy.empty |> add rule_with_deny |> add rule_with_skip'
+
+let make_flag var_name flag =
+  let var = Var.create var_name (Type.Imm 1) in
+  let data' = if flag then Word.b1 else Word.b0 in
+  Value.create register_write (Move.({cell = var; data = data';}))
+
+let flag  = make_flag "CF" true
+let flag' = make_flag "CF" false
+
+let test_denied ctxt =
+  let left  = Events.of_list [make_flag "OF" true; flag; make_flag "SF" true] in
+  let right = Events.of_list [make_flag "OF" true; flag'] in
+  match Policy.denied policy "some insn" left right with
+  | [] -> assert_failure "match result is empty"
+  | (rule, (left', right')) :: [] ->
+    assert_equal ~ctxt ~cmp:Rule.equal rule rule_with_deny;
+    assert_equal ~ctxt [flag] left';
+    assert_equal ~ctxt [flag'] right'
+  | res -> assert_failure "match result is unexpectable long"
+
+let suite () =
+  "Veri rule test" >::: [ 
+    "denied"  >:: test_denied;
+  ]

--- a/tests/veri_policy_test.mli
+++ b/tests/veri_policy_test.mli
@@ -1,0 +1,2 @@
+
+val suite : unit -> OUnit2.test

--- a/tests/veri_rule_test.ml
+++ b/tests/veri_rule_test.ml
@@ -1,0 +1,60 @@
+open Core_kernel.Std
+open OUnit2
+
+module Rule = Veri_rule
+
+let assert_ok descr r = assert_bool descr (Result.is_ok r)
+let assert_er descr r = assert_bool descr (Result.is_error r)
+
+let test_create ctxt = 
+  let insn = "MOV32rr" in
+  assert_ok "abs empty" (Rule.create Rule.skip);
+  assert_ok "only insn" (Rule.create ~insn Rule.skip);
+  assert_ok "only left part" (Rule.create ~left:insn Rule.skip);
+  assert_ok "only right part" (Rule.create ~right:insn Rule.skip);
+  assert_ok "left and right" (Rule.create ~left:insn ~right:insn Rule.skip);
+  assert_ok "regexp on right" (Rule.create ~insn:".*" ~left:insn ~right:".F => .*" Rule.skip);
+  assert_ok "regexp in insn" (Rule.create ~insn:".*" ~left:".F => .*" Rule.skip);
+  assert_ok "backref regexp" (Rule.create ~insn:".*" ~left:"(.F) <= .*" ~right:"\\1 <= .*" Rule.skip);
+  assert_er "error in regexp" (Rule.create ~insn:".*" ~right:"\\1 <= .*" Rule.skip)
+
+let test_create_exn ctxt = 
+  let f () = Rule.create_exn ~insn:".*" ~right:"\\1 <= .*" Rule.skip in
+  assert_raises ~msg:"Bad field not raised!" 
+    (Rule.Bad_field "error in field  \\1 <= .*") f
+
+let test_of_string ctxt = 
+  assert_ok "" (Rule.of_string_err "SKIP .* '.F => .*' ''");
+  assert_ok "" (Rule.of_string_err "DENY .* '(.F) <= .*' '\\1 <= .*'");
+  assert_ok "" (Rule.of_string_err "SKIP .* '.F <= .*' ''");
+  assert_er "" (Rule.of_string_err "SOME_ACTION .* '.F <= .*' ''")
+
+let test_match ctxt = 
+  let base_assert what descr rule field str = 
+    let res = Rule.match_field rule field str in
+    match what with
+    | `Expect_ok -> assert_bool descr res
+    | `Expect_er -> assert_bool descr (not res) in
+  let assert_match = base_assert `Expect_ok in
+  let assert_mismatch = base_assert `Expect_er in
+  assert_match "empty rule" (Rule.create_exn Rule.skip) `Insn  "MOV32rr";
+  assert_mismatch "other insn" (Rule.create_exn Rule.skip ~insn:"MOV64rr") `Insn "MOV32rr";
+  assert_match "any insn" (Rule.create_exn Rule.skip ~insn:".*") `Insn "MOV32rr";
+  assert_match "any left" (Rule.create_exn Rule.skip ~left:".*") `Left "ESP <= 0xC0FFEE";
+  assert_match "any right" (Rule.create_exn Rule.skip ~right:".*") `Right "ESP <= 0xC0FFEE";
+  assert_match "empty field" (Rule.create_exn Rule.skip ~right:".*") `Left "ESP <= 0xC0FFEE";
+  assert_match "backref match" 
+    (Rule.create_exn Rule.skip ~left:"(.SP) <= 0xC0FFEE" ~right:"\\1 <= .*")
+    `Both "ESP <= 0xC0FFEE ESP <= 0xBED";
+  assert_mismatch "backref mismatch" 
+    (Rule.create_exn Rule.skip ~left:"(.F) <= (.*)" ~right:"\\1 <= \\2")
+    `Both "OF <= 0x1 OF <= 0x0"
+
+let suite () =
+  "Veri rule test" >:::
+  [
+    "create"     >:: test_create;
+    "create exn" >:: test_create_exn;
+    "of_string"  >:: test_of_string;
+    "match"      >:: test_match;
+  ]

--- a/tests/veri_rule_test.mli
+++ b/tests/veri_rule_test.mli
@@ -1,0 +1,2 @@
+
+val suite : unit -> OUnit2.test

--- a/tests/veri_stat_test.ml
+++ b/tests/veri_stat_test.ml
@@ -1,0 +1,112 @@
+open Core_kernel.Std
+open OUnit2
+open Veri_error
+
+module Stat = Veri_stat
+module Abs = Stat.Abs
+module Rel = Stat.Rel
+module Names = Stat.Names
+
+let repeat f n stat = 
+  let rec loop i stat = 
+    if i = n then stat 
+    else loop (i + 1) (f stat) in
+  loop 0 stat
+
+let repeat' f data stat = 
+  let rec loop stat = function
+    | [] -> stat
+    | hd :: tl -> loop (f stat hd) tl in
+  loop stat data
+
+let chunk_error = Error.of_string "spoiled chunk"
+let repeat_error n er stat = repeat (fun stat' -> Stat.notify stat' er) n stat
+let repeat_overloaded n stat = repeat_error n `Overloaded_chunk stat
+let repeat_damaged n stat = repeat_error n (`Damaged_chunk chunk_error) stat
+let repeat_undisasmed n stat = repeat_error n (`Disasm_error chunk_error) stat
+
+let add_unlifted =
+  repeat' (fun stat' name -> Stat.notify stat' (`Lifter_error (name, chunk_error)))
+
+let add_failed = repeat' (fun stat' name -> Stat.failbil stat' name)
+let add_successed = repeat' (fun stat' name -> Stat.success stat' name) 
+let mislifted_names = ["CDQ"; "CQO"; "LD_F80m"; "LD_Frr"; "ST_FP80m"]
+let successed_names = ["CMOVA64rr"; "CMOVAE32rr";]
+let abs_successed_names = ["ADD64rr"; "ADD64mr"; "ADD32rr"; "ADD32mr"; ]
+let abs_misexec_names = ["NOOPL"; "NOOPW"; "CMOVAE64rr";]
+
+(** since this both sets describes insns that were sometimes successed and
+    sometimes not *)
+let misexec_names = successed_names 
+
+let is_same xs xs' = 
+  List.length xs = List.length xs' &&
+  List.for_all ~f:(fun x' -> List.exists ~f:(fun x -> x = x') xs) xs'
+
+let overloaded_cnt = 8
+let damaged_cnt = 16
+let undisasmed_cnt = 32
+
+let stat =
+  Stat.empty |>
+  repeat_overloaded overloaded_cnt |>
+  repeat_damaged damaged_cnt       |>
+  repeat_undisasmed undisasmed_cnt |>
+  add_unlifted mislifted_names  |>
+  add_failed (misexec_names @ abs_misexec_names) |>
+  add_successed (successed_names @ abs_successed_names)
+
+let test_abs ctxt =
+  let abs_successed_cnt = List.length abs_successed_names in
+  let successed_cnt = List.length (successed_names @ abs_successed_names) in
+  let abs_misexec_cnt = List.length abs_misexec_names in
+  let misexec_cnt = List.length (misexec_names @ abs_misexec_names) in
+  let mislifted_cnt = List.length mislifted_names in
+  let total = overloaded_cnt + damaged_cnt + undisasmed_cnt + 
+              successed_cnt + misexec_cnt + mislifted_cnt in
+  assert_equal ~ctxt (Abs.successed stat) successed_cnt;
+  assert_equal ~ctxt (Abs.abs_successed stat) abs_successed_cnt;
+  assert_equal ~ctxt (Abs.misexecuted stat) misexec_cnt;
+  assert_equal ~ctxt (Abs.abs_misexecuted stat) abs_misexec_cnt;
+  assert_equal ~ctxt (Abs.overloaded stat) overloaded_cnt;
+  assert_equal ~ctxt (Abs.damaged stat) damaged_cnt;
+  assert_equal ~ctxt (Abs.undisasmed stat) undisasmed_cnt;
+  assert_equal ~ctxt (Abs.mislifted stat) mislifted_cnt;
+  assert_equal ~ctxt (Abs.total stat) total
+
+let test_rel ctxt = 
+  let assert_float descr x y = assert_bool descr (cmp_float x y) in
+  let to_float n = float n /. float (Abs.total stat) in
+  let to_float' xs = to_float (List.length xs) in
+  assert_float "rel successed" 
+    (Rel.successed stat) (to_float' (abs_successed_names @ successed_names));
+  assert_float "rel misexecuted" 
+    (Rel.misexecuted stat) (to_float' (abs_misexec_names @ misexec_names));
+  assert_float "rel abs successed" 
+    (Rel.abs_successed stat) (to_float' abs_successed_names);
+  assert_float "rel abs misexecuted" 
+    (Rel.abs_misexecuted stat) (to_float' abs_misexec_names);
+  assert_float "rel overloaded" (Rel.overloaded stat) (to_float overloaded_cnt);
+  assert_float "rel damaged" (Rel.damaged stat) (to_float damaged_cnt);
+  assert_float "rel undisasmed" (Rel.undisasmed stat) (to_float undisasmed_cnt);
+  assert_float "rel mislifted" (Rel.mislifted stat) (to_float' mislifted_names)
+
+let test_names ctxt =
+  let successed = successed_names @ abs_successed_names in
+  let misexecuted = misexec_names @ abs_misexec_names in
+  assert_bool "successed names" (is_same (Names.successed stat) successed);
+  assert_bool "abs successed names" 
+    (is_same (Names.abs_successed stat) abs_successed_names);
+  assert_bool "misexecuted names" 
+    (is_same (Names.misexecuted stat) misexecuted);
+  assert_bool "abs misexecuted names" 
+    (is_same (Names.abs_misexecuted stat) abs_misexec_names);
+  assert_bool "mislifted names" (is_same (Names.mislifted stat) mislifted_names)
+
+let suite () =
+  "Veri stat test" >:::
+  [
+    "absolute"    >:: test_abs;
+    "relative"    >:: test_rel;
+    "names"  >:: test_names;
+  ]

--- a/tests/veri_stat_test.mli
+++ b/tests/veri_stat_test.mli
@@ -1,0 +1,2 @@
+
+val suite : unit -> OUnit2.test


### PR DESCRIPTION
This PR introduces a first approach to `Veri_policy` module, that allows to write rules like `Action : Instruction : Event : Event`, where possible values for action is either `SKIP` either `DENY` and all other fields are regular expressions. 